### PR TITLE
Feature/yeojin/#331

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tiptap/pm": "^2.11.0",
     "@tiptap/react": "^2.11.0",
     "@tiptap/starter-kit": "^2.11.0",
+    "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^2.11.0
         version: 2.11.0
+      '@vercel/analytics':
+        specifier: ^1.5.0
+        version: 1.5.0(next@15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -882,6 +885,32 @@ packages:
   '@typescript-eslint/visitor-keys@8.18.1':
     resolution: {integrity: sha512-Vj0WLm5/ZsD013YeUKn+K0y8p1M0jPpxOkKdbD1wB0ns53a5piVY02zjf072TblEweAbcYiFiPoSMF3kp+VhhQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vercel/analytics@1.5.0':
+    resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3194,6 +3223,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.18.1
       eslint-visitor-keys: 4.2.0
+
+  '@vercel/analytics@1.5.0(next@15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
+    optionalDependencies:
+      next: 15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
 
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { CheckLoginStatus } from './CheckLoginStatus';
 import Toast from '@/components/common/toast/Toast';
 import Footer from '@/components/landingPage/footer/Footer';
 import ResetSortAndPage from './ResetSortAndPage';
+import { Analytics } from '@vercel/analytics/next';
 
 export const metadata: Metadata = {
   title: '도르멍',
@@ -25,6 +26,7 @@ const RootLayout = ({
           <Header />
           <main className="flex justify-center grow w-full min-h-[cal(100% - 64px)] px-4 mt-16 md:min-h-[cal(100% - 80px)] md:px-6 md:mt-20">
             {children}
+            <Analytics />
           </main>
           <Footer />
           <CheckLoginStatus />


### PR DESCRIPTION
## Vercel Analytics
### 작업 개요
Vercel Web Analytics를 활용해 사용자 이용 추적 기능 도입
전역 RootLayout에 `<Analytics />` 컴포넌트 삽입하여, 모든 페이지 방문 정보 수집할 수 있도록 구성

### 주요 변경 사항
- `@vercel/analytics/next` 패키지 import
- `RootLayout`의 `<main>` 영역에 `<Analytics />` 컴포넌트 삽입
- Vercel 대시보드에서 실시간 페이지뷰 확인 가능

### 기대 효과
- 사용자 흐름 및 페이지별 유입량 파악 가능
- UX 개선 및 페이지 성능 최적화를 위한 기반 데이터 확보
- 외부 분석 도구(GA 등) 없이 간편하게 접근 가능

### 참고 사항
- 별도의 설정이나 이벤트 트래킹 없이 자동 추적 (정적/동적 페이지 모두 포함)
- [Vercel Analytics Docs](https://vercel.com/docs/analytics) 참고