### PR TITLE
[웹 접근성] 후기 작성 텍스트 에디터 툴바 button 태그 변환 및 ARIA 보강

### DIFF
--- a/src/components/travel-reviews/constants.ts
+++ b/src/components/travel-reviews/constants.ts
@@ -21,6 +21,26 @@ export const COLOR_SWATCHES = [
   '#FFFFFF',
 ] as const;
 
+export const COLOR_NAMES: Record<string, string> = {
+  '#FBD6B0': '살구색',
+  '#F8EAC1': '연노랑',
+  '#DBEBCC': '연두',
+  '#D1E6F1': '하늘색',
+  '#CF3F2F': '진한 빨강',
+  '#FF9B36': '주황',
+  '#FBC114': '노랑',
+  '#98DA5B': '연두빛 초록',
+  '#95C9E7': '연파랑',
+  '#0E72D5': '파랑',
+  '#151515': '기본(진한 회색)',
+  '#404040': '어두운 회색',
+  '#6D6D6D': '회색',
+  '#9C9C9C': '중간 회색',
+  '#CECECE': '연회색',
+  '#EFEFEF': '아주 연한 회색',
+  '#FFFFFF': '흰색',
+};
+
 export const TOOLBAR_OUTER_CONTAINER_STYLES =
   'sticky top-16 z-10 w-full bg-background md:top-20' as const;
 

--- a/src/components/travel-reviews/reviewForm/ReviewForm.tsx
+++ b/src/components/travel-reviews/reviewForm/ReviewForm.tsx
@@ -151,6 +151,7 @@ const ReviewForm = ({
               type="text"
               variant="title"
               width="wide"
+              aria-label="후기 제목"
               className="text-base border-green bg-white focus:outline-0"
             />
             {errors.title?.message && <ErrorMessage message={errors.title.message} />}

--- a/src/components/travel-reviews/textEditor/ColorSwatches.tsx
+++ b/src/components/travel-reviews/textEditor/ColorSwatches.tsx
@@ -1,5 +1,5 @@
 import { Square, SquareSlash } from 'lucide-react';
-import { COLOR_SWATCH_STYLES, COLOR_SWATCHES } from '../constants';
+import { COLOR_NAMES, COLOR_SWATCH_STYLES, COLOR_SWATCHES } from '../constants';
 import { ColorSwatchesProps } from '../types';
 
 const ColorSwatches = ({ type, onClick }: ColorSwatchesProps) => {
@@ -10,22 +10,29 @@ const ColorSwatches = ({ type, onClick }: ColorSwatchesProps) => {
 
   return (
     <div className="grid grid-cols-6 justify-items-stretch gap-2 absolute top-8 z-20 w-56 p-3 border border-darkGray rounded-md bg-white text-darkGray drop-shadow-md ">
-      <button type="button">
+      <button type="button" onClick={clickReset} aria-label="색상 초기화">
         <SquareSlash
           size={26}
           strokeWidth={1}
           className={COLOR_SWATCH_STYLES}
-          onClick={clickReset}
+          aria-hidden="true"
+          focusable="false"
         />
       </button>
       {COLOR_SWATCHES.map(color => (
-        <button key={color} type="button">
+        <button
+          key={color}
+          type="button"
+          onClick={() => clickColor(color)}
+          aria-label={COLOR_NAMES[color] || color}
+        >
           <Square
             size={26}
             strokeWidth={1}
             style={{ fill: color }}
             className={COLOR_SWATCH_STYLES}
-            onClick={() => clickColor(color)}
+            aria-hidden="true"
+            focusable="false"
           />
         </button>
       ))}

--- a/src/components/travel-reviews/textEditor/Toolbar.tsx
+++ b/src/components/travel-reviews/textEditor/Toolbar.tsx
@@ -70,12 +70,25 @@ const Toolbar = ({ editor }: ToolbarProps) => {
               ariaLabel="헤딩 선택"
             />
             {((isMobile && showHeadingOptions) || !isMobile) && (
-              <div className={headingToolStyles({ isMobile })}>
+              <div
+                role="radiogroup"
+                aria-label="제목 수준"
+                className={headingToolStyles({ isMobile })}
+              >
                 {getToolbarOptions(editor, 'heading').map((option, index) => (
                   <ToolbarIcon
                     key={option.type}
                     icon={option.icon}
-                    ariaLabel={option.type}
+                    ariaLabel={
+                      option.type === 'h1'
+                        ? '제목 1 적용'
+                        : option.type === 'h2'
+                        ? '제목 2 적용'
+                        : option.type === 'h3'
+                        ? '제목 3 적용'
+                        : option.type
+                    }
+                    roleOverride="radio"
                     isActive={editor.isActive('heading', { level: index + 1 })}
                     onClick={() => option.action()}
                     className="p-2 border-r border-darkerGray last:border-none md:p-0 md:border-none"
@@ -117,19 +130,30 @@ const Toolbar = ({ editor }: ToolbarProps) => {
               <ToolbarIcon
                 key={option.type}
                 icon={option.icon}
-                ariaLabel={option.type}
+                ariaLabel={
+                  option.type === 'bold'
+                    ? '굵게'
+                    : option.type === 'italic'
+                    ? '기울임'
+                    : option.type === 'underline'
+                    ? '밑줄'
+                    : option.type === 'strike'
+                    ? '취소선'
+                    : option.type
+                }
                 isActive={editor.isActive(option.type)}
                 onClick={() => option.action()}
               />
             ))}
           </div>
 
-          <div role="group" aria-label="목록" className={TOOLBAR_GROUP_STYLES}>
+          <div role="radiogroup" aria-label="목록 종류" className={TOOLBAR_GROUP_STYLES}>
             {getToolbarOptions(editor, 'list').map(option => (
               <ToolbarIcon
                 key={option.type}
                 icon={option.icon}
-                ariaLabel={option.type}
+                ariaLabel={option.type === 'bulletList' ? '글머리 기호 목록' : '번호 목록'}
+                roleOverride="radio"
                 isActive={editor.isActive(option.type)}
                 onClick={() => option.action()}
               />

--- a/src/components/travel-reviews/textEditor/Toolbar.tsx
+++ b/src/components/travel-reviews/textEditor/Toolbar.tsx
@@ -59,7 +59,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
 
   return (
     <div className={TOOLBAR_OUTER_CONTAINER_STYLES}>
-      <div className={TOOLBAR_INNER_CONTAINER_STYLES}>
+      <div role="toolbar" aria-label="텍스트 편집 도구" className={TOOLBAR_INNER_CONTAINER_STYLES}>
         <div className="flex gap-3 md:gap-5">
           <div ref={headingRef} className="relative">
             <ToolbarIcon

--- a/src/components/travel-reviews/textEditor/Toolbar.tsx
+++ b/src/components/travel-reviews/textEditor/Toolbar.tsx
@@ -61,7 +61,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
   return (
     <div className={TOOLBAR_OUTER_CONTAINER_STYLES}>
       <div role="toolbar" aria-label="텍스트 편집 도구" className={TOOLBAR_INNER_CONTAINER_STYLES}>
-        <div className="flex gap-3 md:gap-5">
+        <div role="group" aria-label="제목 서식" className="flex gap-3 md:gap-5">
           <div ref={headingRef} className="relative">
             <ToolbarIcon
               icon={Heading}
@@ -85,7 +85,12 @@ const Toolbar = ({ editor }: ToolbarProps) => {
             )}
           </div>
 
-          <div className={twMerge(TOOLBAR_GROUP_STYLES, 'relative')} ref={colorRef}>
+          <div
+            role="group"
+            aria-label="색상"
+            className={twMerge(TOOLBAR_GROUP_STYLES, 'relative')}
+            ref={colorRef}
+          >
             {getToolbarOptions(editor, 'color').map(option => (
               <ToolbarIcon
                 key={option.type}
@@ -107,7 +112,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
               <ColorSwatches type={colorSwatchMode} onClick={() => editor.chain().focus()} />
             )}
           </div>
-          <div className={TOOLBAR_GROUP_STYLES}>
+          <div role="group" aria-label="서식" className={TOOLBAR_GROUP_STYLES}>
             {getToolbarOptions(editor, 'style').map(option => (
               <ToolbarIcon
                 key={option.type}
@@ -119,7 +124,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
             ))}
           </div>
 
-          <div className={TOOLBAR_GROUP_STYLES}>
+          <div role="group" aria-label="목록" className={TOOLBAR_GROUP_STYLES}>
             {getToolbarOptions(editor, 'list').map(option => (
               <ToolbarIcon
                 key={option.type}
@@ -150,7 +155,11 @@ const Toolbar = ({ editor }: ToolbarProps) => {
           </div>
         </div>
 
-        <div className={clsx(TOOLBAR_GROUP_STYLES, isMobile && 'hidden')}>
+        <div
+          role="group"
+          aria-label="편집 기록 제어"
+          className={clsx(TOOLBAR_GROUP_STYLES, isMobile && 'hidden')}
+        >
           <ToolbarIcon
             icon={Undo}
             ariaLabel="실행 취소"

--- a/src/components/travel-reviews/textEditor/Toolbar.tsx
+++ b/src/components/travel-reviews/textEditor/Toolbar.tsx
@@ -27,6 +27,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
 
   const colorRef = useRef<HTMLDivElement | null>(null);
   const headingRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   useOutsideClick({ ref: colorRef, callback: () => setColorSwatchMode(null) });
   useOutsideClick({ ref: headingRef, callback: () => setShowHeadingOptions(false) });
@@ -132,13 +133,20 @@ const Toolbar = ({ editor }: ToolbarProps) => {
 
           <div className="relative flex items-center">
             <input
+              id="review-image-upload"
+              ref={fileInputRef}
               type="file"
               accept="image/*"
-              className="absolute top-0 left-0 size-5 opacity-0 file:cursor-pointer md:size-6"
+              className="sr-only"
+              tabIndex={-1}
               aria-label="이미지 업로드"
               onChange={handleUploadImage}
             />
-            <ToolbarIcon icon={Image} ariaLabel="이미지 업로드" />
+            <ToolbarIcon
+              icon={Image}
+              ariaLabel="이미지 업로드"
+              onClick={() => fileInputRef.current?.click()}
+            />
           </div>
         </div>
 

--- a/src/components/travel-reviews/textEditor/Toolbar.tsx
+++ b/src/components/travel-reviews/textEditor/Toolbar.tsx
@@ -130,6 +130,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
               type="file"
               accept="image/*"
               className="absolute top-0 left-0 size-5 opacity-0 file:cursor-pointer md:size-6"
+              aria-label="이미지 업로드"
               onChange={handleUploadImage}
             />
             <ToolbarIcon icon={Image} />

--- a/src/components/travel-reviews/textEditor/Toolbar.tsx
+++ b/src/components/travel-reviews/textEditor/Toolbar.tsx
@@ -66,6 +66,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
               icon={Heading}
               onClick={() => setShowHeadingOptions(prev => !prev)}
               className="md:hidden"
+              ariaLabel="헤딩 선택"
             />
             {((isMobile && showHeadingOptions) || !isMobile) && (
               <div className={headingToolStyles({ isMobile })}>
@@ -73,6 +74,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
                   <ToolbarIcon
                     key={option.type}
                     icon={option.icon}
+                    ariaLabel={option.type}
                     isActive={editor.isActive('heading', { level: index + 1 })}
                     onClick={() => option.action()}
                     className="p-2 border-r border-darkerGray last:border-none md:p-0 md:border-none"
@@ -87,6 +89,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
               <ToolbarIcon
                 key={option.type}
                 icon={option.icon}
+                ariaLabel={option.type}
                 onClick={() => {
                   if (!colorSwatchMode) setColorSwatchMode(option.type);
                   else if (colorSwatchMode === option.type) setColorSwatchMode(null);
@@ -108,6 +111,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
               <ToolbarIcon
                 key={option.type}
                 icon={option.icon}
+                ariaLabel={option.type}
                 isActive={editor.isActive(option.type)}
                 onClick={() => option.action()}
               />
@@ -119,6 +123,7 @@ const Toolbar = ({ editor }: ToolbarProps) => {
               <ToolbarIcon
                 key={option.type}
                 icon={option.icon}
+                ariaLabel={option.type}
                 isActive={editor.isActive(option.type)}
                 onClick={() => option.action()}
               />
@@ -133,13 +138,21 @@ const Toolbar = ({ editor }: ToolbarProps) => {
               aria-label="이미지 업로드"
               onChange={handleUploadImage}
             />
-            <ToolbarIcon icon={Image} />
+            <ToolbarIcon icon={Image} ariaLabel="이미지 업로드" />
           </div>
         </div>
 
         <div className={clsx(TOOLBAR_GROUP_STYLES, isMobile && 'hidden')}>
-          <ToolbarIcon icon={Undo} onClick={() => editor.chain().focus().undo().run()} />
-          <ToolbarIcon icon={Redo} onClick={() => editor.chain().focus().redo().run()} />
+          <ToolbarIcon
+            icon={Undo}
+            ariaLabel="실행 취소"
+            onClick={() => editor.chain().focus().undo().run()}
+          />
+          <ToolbarIcon
+            icon={Redo}
+            ariaLabel="다시 실행"
+            onClick={() => editor.chain().focus().redo().run()}
+          />
         </div>
       </div>
     </div>

--- a/src/components/travel-reviews/textEditor/ToolbarIcon.tsx
+++ b/src/components/travel-reviews/textEditor/ToolbarIcon.tsx
@@ -3,7 +3,14 @@ import clsx from 'clsx';
 import { ToolbarIconProps } from '../types';
 import { twMerge } from 'tailwind-merge';
 
-const ToolbarIcon = ({ icon: ICON, isActive, onClick, className, ariaLabel }: ToolbarIconProps) => {
+const ToolbarIcon = ({
+  icon: ICON,
+  isActive,
+  onClick,
+  className,
+  ariaLabel,
+  roleOverride,
+}: ToolbarIconProps) => {
   const isMobile = useIsMobile();
   return (
     <button
@@ -12,6 +19,8 @@ const ToolbarIcon = ({ icon: ICON, isActive, onClick, className, ariaLabel }: To
       onClick={onClick}
       aria-label={ariaLabel || '툴바 아이콘'}
       aria-pressed={isActive}
+      aria-checked={isActive}
+      role={roleOverride}
     >
       <ICON
         width={isMobile ? 20 : 23}

--- a/src/components/travel-reviews/textEditor/ToolbarIcon.tsx
+++ b/src/components/travel-reviews/textEditor/ToolbarIcon.tsx
@@ -3,10 +3,16 @@ import clsx from 'clsx';
 import { ToolbarIconProps } from '../types';
 import { twMerge } from 'tailwind-merge';
 
-const ToolbarIcon = ({ icon: ICON, isActive, onClick, className }: ToolbarIconProps) => {
+const ToolbarIcon = ({ icon: ICON, isActive, onClick, className, ariaLabel }: ToolbarIconProps) => {
   const isMobile = useIsMobile();
   return (
-    <button type="button" className={className} onClick={onClick} aria-pressed={isActive}>
+    <button
+      type="button"
+      className={className}
+      onClick={onClick}
+      aria-label={ariaLabel || '툴바 아이콘'}
+      aria-pressed={isActive}
+    >
       <ICON
         width={isMobile ? 20 : 23}
         height={isMobile ? 20 : 23}

--- a/src/components/travel-reviews/textEditor/ToolbarIcon.tsx
+++ b/src/components/travel-reviews/textEditor/ToolbarIcon.tsx
@@ -6,9 +6,10 @@ import { twMerge } from 'tailwind-merge';
 const ToolbarIcon = ({ icon: ICON, isActive, onClick, className }: ToolbarIconProps) => {
   const isMobile = useIsMobile();
   return (
-    <div className={className}>
+    <button type="button" className={className} onClick={onClick} aria-pressed={isActive}>
       <ICON
-        size={isMobile ? '20' : '23'}
+        width={isMobile ? 20 : 23}
+        height={isMobile ? 20 : 23}
         strokeWidth={isActive ? '2.5' : '1.5'}
         className={twMerge(
           clsx(
@@ -16,9 +17,10 @@ const ToolbarIcon = ({ icon: ICON, isActive, onClick, className }: ToolbarIconPr
             'cursor-pointer hover:text-logo hover:scale-110',
           ),
         )}
-        onClick={onClick}
+        aria-hidden="true"
+        focusable="false"
       />
-    </div>
+    </button>
   );
 };
 

--- a/src/components/travel-reviews/types.ts
+++ b/src/components/travel-reviews/types.ts
@@ -30,6 +30,7 @@ export type ToolbarIconProps = {
   isActive?: boolean;
   onClick?: () => void;
   className?: string;
+  ariaLabel?: string;
 };
 
 export type ColorSwatchesProps = { type: string; onClick: () => ChainedCommands };

--- a/src/components/travel-reviews/types.ts
+++ b/src/components/travel-reviews/types.ts
@@ -31,6 +31,7 @@ export type ToolbarIconProps = {
   onClick?: () => void;
   className?: string;
   ariaLabel?: string;
+  roleOverride?: React.AriaRole;
 };
 
 export type ColorSwatchesProps = { type: string; onClick: () => ChainedCommands };


### PR DESCRIPTION
# 이슈번호
#334 

## 작업 내용
- 텍스트 에디터 툴바의 접근성 개선
  - `role="toolbar"` 및 `role="group"` 적용, 그룹별 `aria-label` 부여 (서식, 목록 등)
  - `ToolbarIcon` 컴포넌트를 `div` → `button`으로 교체하여 시멘틱 구조 강화
  - 각 버튼에 접근 가능한 이름(`aria-label`) 추가
  - Bold/Italic 등 토글 버튼에 `aria-pressed` 적용
  - Heading/목록/컬러 선택 등 상호배타 그룹에 적절한 ARIA 패턴 적용
  - 숨겨진 파일 입력에 `aria-label` 부여 및 아이콘 버튼과 연계
